### PR TITLE
fix flaky-test in ParametrizedUriEmitterTest#testEmitterWithParametrizedUriExtractor

### DIFF
--- a/processing/src/test/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitterTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitterTest.java
@@ -40,7 +40,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
-
 public class ParametrizedUriEmitterTest
 {
   private static final ObjectMapper JSON_MAPPER = new ObjectMapper();

--- a/processing/src/test/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitterTest.java
+++ b/processing/src/test/java/org/apache/druid/java/util/emitter/core/ParametrizedUriEmitterTest.java
@@ -21,7 +21,6 @@ package org.apache.druid.java.util.emitter.core;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.ObjectWriter;
 import com.google.common.collect.ImmutableMap;
 import org.apache.druid.java.util.common.StringUtils;
 import org.apache.druid.java.util.common.lifecycle.Lifecycle;
@@ -34,15 +33,13 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import java.util.TreeMap;
+
 
 public class ParametrizedUriEmitterTest
 {
@@ -180,20 +177,14 @@ public class ParametrizedUriEmitterTest
           protected ListenableFuture<Response> go(Request request) throws JsonProcessingException
           {
             Assert.assertEquals("http://example.com/val1/val2", request.getUrl());
-            String event1Json = sortedJsonStrings(JSON_MAPPER.writeValueAsString(events.get(0)));
-            String event2Json = sortedJsonStrings(JSON_MAPPER.writeValueAsString(events.get(1)));
-            String expectedJsonContent = "[ " + event1Json + ", " + event2Json + " ]";
-            byte[] requestBytes = request.getByteBufferData().slice().array();
-            String actualJsonContent = StandardCharsets.UTF_8.decode(ByteBuffer.wrap(requestBytes)).toString();
-            List<Map<String, Object>> jsonArray = new ObjectMapper().readValue(actualJsonContent, List.class);
-            List<Map<String, Object>> sortedJsonArray = new ArrayList<>();
-            for (Map<String, Object> map : jsonArray) {
-              Map<String, Object> sortedMap = new TreeMap<>(map);
-              sortedJsonArray.add(sortedMap);
-            }
-            ObjectWriter writer = new ObjectMapper().writerWithDefaultPrettyPrinter();
-            String sorted = writer.writeValueAsString(sortedJsonArray);
-            Assert.assertEquals(expectedJsonContent, sorted);
+            Assert.assertEquals(
+                JSON_MAPPER.readTree(StringUtils.format(
+                    "[%s,%s]\n",
+                    JSON_MAPPER.writeValueAsString(events.get(0)),
+                    JSON_MAPPER.writeValueAsString(events.get(1))
+                )),
+                JSON_MAPPER.readTree(StandardCharsets.UTF_8.decode(request.getByteBufferData().slice()).toString())
+            );
             return GoHandlers.immediateFuture(EmitterTest.okResponse());
           }
         }.times(1)
@@ -205,15 +196,7 @@ public class ParametrizedUriEmitterTest
     emitter.flush();
     Assert.assertTrue(httpClient.succeeded());
   }
-  private String sortedJsonStrings(String jsonString) throws JsonProcessingException 
-  {
-    ObjectMapper objectMapper = new ObjectMapper();
-    Map<String, Object> map = objectMapper.readValue(jsonString, Map.class);
-    Map<String, Object> sortedMap = new TreeMap<>(map);
 
-    ObjectWriter writer = objectMapper.writerWithDefaultPrettyPrinter();
-    return writer.writeValueAsString(sortedMap);
-  }
   @Test
   public void failEmitMalformedEvent() throws Exception
   {


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->


<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

#### Test failure Reproduction
```
mvn install -pl processing -am -DskipTests
mvn -pl processing test-Dtest=org.apache.druid.java.util.emitter.core.ParametrizedUriEmitterTest#testEmitterWithParametrizedUriExtractor
```
#### Root cause and fix
This error is caused by line 177. 
```
Assert.assertEquals(
                StringUtils.format(
                    "[%s,%s]\n",
                    JSON_MAPPER.writeValueAsString(events.get(0)),
                    JSON_MAPPER.writeValueAsString(events.get(1))
                ),
                StandardCharsets.UTF_8.decode(request.getByteBufferData().slice()).toString()
            );
```
It try to compare Json object data to a fixed string. The Json object data that get by request is non-deterministic. This means the data order in the Json object may change in every request.

To solve the problem, I sort the Json object data and expected data to ensure that they are both in same format and order. This preprocessing will make Json data in a fix order in every time comparasion.

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the bug ...
Fix flaky-test
#### Renamed the class ...
#### Added a forbidden-apis entry ...
Add <dependency> org.skyscreamer to processing/pom.xml
<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

#### Release note
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `MyFoo`
 * `OurBar`
 * `TheirBaz`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [ ] been self-reviewed.
- [ ] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [ ] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [ ] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [ ] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
