### PR TITLE
Fix flaky tests in server, services,

### DIFF
--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/NestedColumnParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/NestedColumnParquetReaderTest.java
@@ -21,6 +21,7 @@ package org.apache.druid.data.input.parquet;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.druid.data.input.ColumnsFilter;
 import org.apache.druid.data.input.InputEntityReader;
 import org.apache.druid.data.input.InputRow;
@@ -219,7 +220,7 @@ public class NestedColumnParquetReaderTest extends BaseParquetReaderTest
     );
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals(new HashSet<>(ImmutableList.of("nestedData", "dim1", "metric1")), new HashSet<>(rows.get(0).getDimensions()));
+    Assert.assertEquals(ImmutableSet.of("nestedData", "dim1", "metric1"), new HashSet<>(rows.get(0).getDimensions()));
     Assert.assertEquals(FlattenSpecParquetInputTest.TS1, rows.get(0).getTimestamp().toString());
     Assert.assertEquals(ImmutableList.of("d1v1"), rows.get(0).getDimension("dim1"));
     Assert.assertEquals("d1v1", rows.get(0).getRaw("dim1"));

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/NestedColumnParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/NestedColumnParquetReaderTest.java
@@ -39,6 +39,7 @@ import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.HashSet;
 import java.util.List;
 
 public class NestedColumnParquetReaderTest extends BaseParquetReaderTest
@@ -218,7 +219,7 @@ public class NestedColumnParquetReaderTest extends BaseParquetReaderTest
     );
 
     List<InputRow> rows = readAllRows(reader);
-    Assert.assertEquals(ImmutableList.of("nestedData", "dim1", "metric1"), rows.get(0).getDimensions());
+    Assert.assertEquals(new HashSet<>(ImmutableList.of("nestedData", "dim1", "metric1")), new HashSet<>(rows.get(0).getDimensions()));
     Assert.assertEquals(FlattenSpecParquetInputTest.TS1, rows.get(0).getTimestamp().toString());
     Assert.assertEquals(ImmutableList.of("d1v1"), rows.get(0).getDimension("dim1"));
     Assert.assertEquals("d1v1", rows.get(0).getRaw("dim1"));

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/WikiParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/WikiParquetReaderTest.java
@@ -99,6 +99,7 @@ public class WikiParquetReaderTest extends BaseParquetReaderTest
                                 + "  \"foo\" : \"baz\",\n"
                                 + "  \"time\" : 1678853101621\n"
                                 + "}";
-    Assert.assertEquals(expectedJson, DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues()));
+    ObjectMapper mapper = new ObjectMapper();
+    Assert.assertEquals(mapper.readTree(expectedJson), mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 }

--- a/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/WikiParquetReaderTest.java
+++ b/extensions-core/parquet-extensions/src/test/java/org/apache/druid/data/input/parquet/WikiParquetReaderTest.java
@@ -99,7 +99,6 @@ public class WikiParquetReaderTest extends BaseParquetReaderTest
                                 + "  \"foo\" : \"baz\",\n"
                                 + "  \"time\" : 1678853101621\n"
                                 + "}";
-    ObjectMapper mapper = new ObjectMapper();
-    Assert.assertEquals(mapper.readTree(expectedJson), mapper.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
+    Assert.assertEquals(JSON_MAPPER.readTree(expectedJson), JSON_MAPPER.readTree(DEFAULT_JSON_WRITER.writeValueAsString(sampled.get(0).getRawValues())));
   }
 }

--- a/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
+++ b/indexing-service/src/test/java/org/apache/druid/indexing/overlord/TaskLockboxTest.java
@@ -82,6 +82,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -1193,11 +1194,11 @@ public class TaskLockboxTest
     Assert.assertEquals(2, lockedIntervals.size());
 
     Assert.assertEquals(
-        Arrays.asList(
+        new HashSet<>(Arrays.asList(
             Intervals.of("2017-01-01/2017-02-01"),
             Intervals.of("2017-04-01/2017-05-01")
-        ),
-        lockedIntervals.get(task1.getDataSource())
+        )),
+        new HashSet<>(lockedIntervals.get(task1.getDataSource()))
     );
 
     Assert.assertEquals(

--- a/server/src/test/java/org/apache/druid/discovery/BaseNodeRoleWatcherTest.java
+++ b/server/src/test/java/org/apache/druid/discovery/BaseNodeRoleWatcherTest.java
@@ -128,7 +128,7 @@ public class BaseNodeRoleWatcherTest
   private void assertListener(TestListener listener, boolean nodeViewInitialized, List<DiscoveryDruidNode> nodesAdded, List<DiscoveryDruidNode> nodesRemoved)
   {
     Assert.assertEquals(nodeViewInitialized, listener.nodeViewInitialized.get());
-    Assert.assertEquals(nodesAdded, listener.nodesAddedList);
+    Assert.assertEquals(new HashSet<>(nodesAdded), new HashSet<>(listener.nodesAddedList));
     Assert.assertEquals(nodesRemoved, listener.nodesRemovedList);
   }
 

--- a/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStatusTest.java
+++ b/server/src/test/java/org/apache/druid/indexing/overlord/supervisor/SupervisorStatusTest.java
@@ -64,6 +64,6 @@ public class SupervisorStatusTest
     Assert.assertEquals("wikipedia", deserialized.getId());
     final String serialized = mapper.writeValueAsString(deserialized);
     Assert.assertTrue(serialized.contains("\"source\""));
-    Assert.assertEquals(json, serialized);
+    Assert.assertEquals(mapper.readTree(json), mapper.readTree(serialized));
   }
 }

--- a/server/src/test/java/org/apache/druid/metadata/input/SqlEntityTest.java
+++ b/server/src/test/java/org/apache/druid/metadata/input/SqlEntityTest.java
@@ -78,7 +78,7 @@ public class SqlEntityTest
     String expectedJson = mapper.writeValueAsString(
         Collections.singletonList(((MapBasedInputRow) expectedRow).getEvent())
     );
-    Assert.assertEquals(actualJson, expectedJson);
+    Assert.assertEquals(mapper.readTree(actualJson), mapper.readTree(expectedJson));
     testUtils.dropTable(TABLE_NAME_1);
   }
 

--- a/services/src/test/java/org/apache/druid/server/router/TieredBrokerHostSelectorTest.java
+++ b/services/src/test/java/org/apache/druid/server/router/TieredBrokerHostSelectorTest.java
@@ -55,6 +55,7 @@ import javax.annotation.Nullable;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -367,18 +368,18 @@ public class TieredBrokerHostSelectorTest
   {
     Assert.assertEquals(
         ImmutableMap.of(
-            "mediumBroker", ImmutableList.of(),
-            "coldBroker", ImmutableList.of("coldHost1:8080", "coldHost2:8080"),
-            "hotBroker", ImmutableList.of("hotHost:8080")
+            "mediumBroker", ImmutableSet.of(),
+            "coldBroker", ImmutableSet.of("coldHost1:8080", "coldHost2:8080"),
+            "hotBroker", ImmutableSet.of("hotHost:8080")
         ),
         Maps.transformValues(
             brokerSelector.getAllBrokers(),
-            new Function<List<Server>, List<String>>()
+            new Function<List<Server>, HashSet<String>>()
             {
               @Override
-              public List<String> apply(@Nullable List<Server> servers)
+              public HashSet<String> apply(@Nullable List<Server> servers)
               {
-                return Lists.transform(servers, server -> server.getHost());
+                return new HashSet<>(Lists.transform(servers, server -> server.getHost()));
               }
             }
         )


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

I found some flaky tests using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) Plugin for maven

<!-- Replace XXXX with the id of the issue fixed in this PR. Remove this section if there is no corresponding issue. Don't reference the issue in the title of this pull-request. -->

<!-- If you are a committer, follow the PR action item checklist for committers:
https://github.com/apache/druid/blob/master/dev/committer-instructions.md#pr-and-issue-action-item-checklist-for-committers. -->

### Description

<!-- Describe the goal of this PR, what problem are you fixing. If there is a corresponding issue (referenced above), it's not necessary to repeat the description here, however, you may choose to keep one summary sentence. -->

<!-- Describe your patch: what did you change in code? How did you fix the problem? -->

<!-- If there are several relatively logically separate changes in this PR, create a mini-section for each of them. For example: -->

#### Fixed the following flaky tests:
#### `services` module:
1. org.apache.druid.server.router.TieredBrokerHostSelectorTest#testGetAllBrokers

#### `indexing-service` module:
2. org.apache.druid.indexing.overlord.TaskLockboxTest#testGetLockedIntervals

#### `extensions-core/parquet-extensions` module:
3. org.apache.druid.data.input.parquet.WikiParquetReaderTest#testUint32Datatype
4. org.apache.druid.data.input.parquet.NestedColumnParquetReaderTest#testNestedColumnSchemalessNestedTestFile

#### `server` module:
5. org.apache.druid.discovery.BaseNodeRoleWatcherTest#testGeneralUseSimulation
6. org.apache.druid.indexing.overlord.supervisor.SupervisorStatusTest#testJsonAttr
7. org.apache.druid.metadata.input.SqlEntityTest#testExecuteQuery


#### Problem:
The above mentioned tests have been reported as flaky (tests assuming deterministic implementation of a non-deterministic specification ) when ran against the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool. 

The tests contain assertions that compare strings created from JSON objects (3, 6, 7) and lists created from HashSets and HashMaps (1, 2, 4, 5). 

However, HashSet does not guarantee the ordering of elements and thus resulting in these flaky tests that assume deterministic implementation of HashSet. Also, It checks for a specific ordering of elements in a JSON string. JSON strings are equal even if the ordering of the elements in the JSON strings are not equal. This results in flakiness as the Jackson ObjectMapper does not guarantee consistent ordering of the JSON keys.

Thus, when the NonDex tool shuffles the HashSet elements and the JSON keys, it results in test failures:
`Github Issue<TODO>`

To reproduce run:
```
mvn -pl <module_name> edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=<test_name>
```

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->

<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->

#### Fix:
For the tests failing due to inequality in ordering of objects in lists that were created from HashSets or HashMaps, first convert the arraylists to hashSets and then compare the 2 HashSets using assertEquals().

For all the tests failing due to inequality in ordering of keys in JSON strings, first create the JSON node trees and then compare the two trees using assertEquals().

##### Key changed/added classes in this PR
- `org.apache.druid.data.input.parquet.NestedColumnParquetReaderTest`
- `org.apache.druid.data.input.parquet.WikiParquetReaderTest`
- `org.apache.druid.indexing.overlord.TaskLockboxTest`
- `org.apache.druid.discovery.BaseNodeRoleWatcherTest`
- `org.apache.druid.indexing.overlord.supervisor.SupervisorStatusTest`
- `org.apache.druid.metadata.input.SqlEntityTest`
- `org.apache.druid.server.router.TieredBrokerHostSelectorTest.java`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
